### PR TITLE
Added new parameters to hook 'is_iu_post_user_import'

### DIFF
--- a/import-users-from-csv.php
+++ b/import-users-from-csv.php
@@ -329,7 +329,7 @@ class IS_IU_Import_Users {
 					}
 
 					// Some plugins may need to do things after one user has been imported. Who know?
-					do_action( 'is_iu_post_user_import', $user_id );
+					do_action( 'is_iu_post_user_import', $user_id, $userdata, $usermeta );
 
 					$user_ids[] = $user_id;
 				}


### PR DESCRIPTION
Now you can access imported user-data or meta-data after successful import, without loading it from the database again.

Of course, this data is raw, means not modified by any filters or hooks, which would have been applied during the process of saving the user data and its meta fields.

Signed-off-by: Matthias Lohscheidt matti@dergreif-online.de
